### PR TITLE
Add flex grid configuration documentation

### DIFF
--- a/src/app/showcase/components/flexgrid/flexgriddemo.html
+++ b/src/app/showcase/components/flexgrid/flexgriddemo.html
@@ -424,6 +424,25 @@
             <p>FlexGrid is a CSS utility based on flexbox. For more information about Flex, visit <a href="https://css-tricks.com/snippets/css/a-guide-to-flexbox/">A Complete Guide to Flexbox</a>. A basic grid is defined by giving
             a container "p-grid" class and children the ".p-col" class. Children of the grid will have the same width and scale according to the width of the parent.</p>
 <pre>
+
+<h3>Download</h3>
+    <p>PrimeFlex is available at npm, if you have an existing application run the following command to download it to your project.</p>
+<pre>
+<code class="language-markup" pCode ngNonBindable>
+npm install primeflex --save
+</code>
+</pre>
+
+ <h4>Styles Configuration</h4>
+    <p>Configure required style at the styles section.</p>
+<pre>
+<code class="language-js" pCode ngNonBindable>
+"styles": [
+  "node_modules/primeflex/primeflex.css"
+],
+</code>
+</pre>
+
 <code class="language-markup" pCode ngNonBindable>
 &lt;div class="p-grid"&gt;
     &lt;div class="p-col"&gt;1&lt;/div&gt;


### PR DESCRIPTION
###Defect Fixes
In the flex grid portion, there is no specific instruction of using PrimeFlex. So, this makes confusion. It will be easier for developers if the download and style configuration instructions are specified.